### PR TITLE
feat: build website from content strategy

### DIFF
--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -1,0 +1,23 @@
+import { aboutMe } from "@/data/resume";
+
+const AboutSection = () => {
+  return (
+    <section id="about" className="py-24 bg-card">
+      <div className="section-container">
+        <div className="max-w-3xl mx-auto text-center">
+          <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-8">
+            About Me
+          </h2>
+          <p className="text-lg text-muted-foreground leading-relaxed mb-6">
+            {aboutMe.summary}
+          </p>
+          <p className="text-base text-muted-foreground/80 leading-relaxed">
+            {aboutMe.biography}
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default AboutSection;

--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -1,0 +1,55 @@
+import { Mail, Linkedin, Github } from "lucide-react";
+import { personalInfo } from "@/data/resume";
+
+const ContactSection = () => {
+  return (
+    <section id="contact" className="py-24 bg-card">
+      <div className="section-container">
+        <div className="max-w-2xl mx-auto text-center">
+          <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
+            Let's Build Something Together
+          </h2>
+          <p className="text-lg text-muted-foreground mb-10">
+            Open to new opportunities and interesting data challenges.
+          </p>
+
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
+            <a
+              href={`mailto:${personalInfo.email}`}
+              className="btn-primary inline-flex items-center gap-2 w-full sm:w-auto justify-center"
+            >
+              <Mail className="w-4 h-4" />
+              {personalInfo.email}
+            </a>
+            <a
+              href={`https://${personalInfo.linkedin}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="btn-outline inline-flex items-center gap-2 w-full sm:w-auto justify-center"
+            >
+              <Linkedin className="w-4 h-4" />
+              LinkedIn
+            </a>
+            <a
+              href={`https://${personalInfo.github}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="btn-outline inline-flex items-center gap-2 w-full sm:w-auto justify-center"
+            >
+              <Github className="w-4 h-4" />
+              GitHub
+            </a>
+          </div>
+
+          {personalInfo.phone && (
+            <p className="mt-6 text-sm text-muted-foreground font-mono">
+              {personalInfo.phone}
+            </p>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default ContactSection;

--- a/src/components/EducationSection.tsx
+++ b/src/components/EducationSection.tsx
@@ -1,0 +1,58 @@
+import { GraduationCap } from "lucide-react";
+import { education, languages } from "@/data/resume";
+
+const EducationSection = () => {
+  return (
+    <section id="education" className="py-24 bg-background">
+      <div className="section-container">
+        <div className="text-center mb-16">
+          <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
+            Education
+          </h2>
+        </div>
+
+        <div className="max-w-3xl mx-auto">
+          {/* Education entries */}
+          <div className="space-y-6 mb-12">
+            {education.map((edu, index) => (
+              <div
+                key={`${edu.institution}-${edu.startYear}`}
+                className="flex items-start gap-4 p-5 rounded-xl bg-card border border-border animate-fade-up"
+                style={{ animationDelay: `${index * 0.1}s` }}
+              >
+                <div className="flex-shrink-0 w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center">
+                  <GraduationCap className="w-5 h-5 text-primary" />
+                </div>
+                <div className="flex-1">
+                  <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1">
+                    <h3 className="font-bold text-foreground">
+                      {edu.degree} — {edu.field}
+                    </h3>
+                    <span className="text-sm text-muted-foreground font-mono">
+                      {edu.startYear}–{edu.endYear}
+                    </span>
+                  </div>
+                  <p className="text-muted-foreground text-sm mt-1">{edu.institution}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Languages */}
+          <div className="text-center">
+            <h3 className="text-lg font-bold text-foreground mb-4">Languages</h3>
+            <div className="flex justify-center gap-4 flex-wrap">
+              {languages.map((lang) => (
+                <span key={lang.language} className="skill-tag">
+                  {lang.language} <span className="text-muted-foreground ml-1">({lang.proficiency})</span>
+                </span>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default EducationSection;

--- a/src/components/ExperienceSection.tsx
+++ b/src/components/ExperienceSection.tsx
@@ -1,84 +1,81 @@
-import serversIllustration from "@/assets/servers-illustration.png";
-
-interface ExperienceItem {
-  number: number;
-  company: string;
-  role: string;
-  description: string;
-}
-
-const experiences: ExperienceItem[] = [
-  {
-    number: 1,
-    company: "Xebia Data",
-    role: "Senior Data Engineer",
-    description: "Spearheaded IoT data integration for Irish Railways. Designed scalable pipelines using Apache NiFi, Grafana dashboards, and TimescaleDB."
-  },
-  {
-    number: 2,
-    company: "ING",
-    role: "Data Engineer",
-    description: "Built sustainability reports on Azure K8s. Developed PySpark pipelines with Airflow and Kedro, optimizing performance across the GAIA team."
-  },
-  {
-    number: 3,
-    company: "Coca-Cola İçecek",
-    role: "Big Data Engineer",
-    description: "Architected ML and Big Data solutions on GCP and AWS. Defined data structures and led hands-on pipeline development."
-  }
-];
+import { Briefcase } from "lucide-react";
+import { experiences } from "@/data/resume";
 
 const ExperienceSection = () => {
   return (
-    <section className="py-24 bg-card">
+    <section id="experience" className="py-24 bg-background">
       <div className="section-container">
         {/* Section Header */}
         <div className="text-center mb-16">
-          <h2 className="font-serif text-4xl md:text-5xl font-bold text-foreground mb-4">
+          <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
             Professional Experience
           </h2>
           <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
-            14+ years spanning software development and data engineering across prestigious global organizations.
+            13+ years spanning software development, data engineering, and cloud architecture across major enterprises.
           </p>
         </div>
-        
-        {/* Content Grid */}
-        <div className="grid lg:grid-cols-2 gap-12 items-center">
-          {/* Experience List */}
-          <div className="space-y-8">
+
+        {/* Timeline */}
+        <div className="relative">
+          {/* Vertical line */}
+          <div className="absolute left-4 md:left-8 top-0 bottom-0 w-px bg-border" />
+
+          <div className="space-y-12">
             {experiences.map((exp, index) => (
-              <div 
-                key={exp.number}
-                className="flex gap-6 animate-fade-up"
-                style={{ animationDelay: `${index * 0.15}s` }}
+              <div
+                key={`${exp.company}-${exp.startDate}`}
+                className="relative pl-12 md:pl-20 animate-fade-up"
+                style={{ animationDelay: `${index * 0.1}s` }}
               >
-                {/* Number Badge */}
-                <div className="flex-shrink-0">
-                  <div className="number-badge">
-                    {exp.number}
-                  </div>
+                {/* Timeline dot */}
+                <div className="absolute left-2 md:left-6 top-1 w-5 h-5 rounded-full bg-primary/20 border-2 border-primary flex items-center justify-center">
+                  <div className="w-2 h-2 rounded-full bg-primary" />
                 </div>
-                
-                {/* Content */}
-                <div>
-                  <h3 className="font-serif text-xl font-semibold text-foreground mb-1">
-                    {exp.company} — <span className="text-primary">{exp.role}</span>
-                  </h3>
-                  <p className="text-muted-foreground leading-relaxed">
+
+                {/* Card */}
+                <div className="card-soft">
+                  {/* Header */}
+                  <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-2 mb-3">
+                    <div>
+                      <h3 className="text-xl font-bold text-foreground">
+                        {exp.title}
+                      </h3>
+                      <p className="text-primary font-medium flex items-center gap-2">
+                        <Briefcase className="w-4 h-4" />
+                        {exp.company}
+                      </p>
+                    </div>
+                    <span className="text-sm text-muted-foreground font-mono whitespace-nowrap">
+                      {exp.startDate} — {exp.endDate}
+                    </span>
+                  </div>
+
+                  {/* Description */}
+                  <p className="text-muted-foreground mb-4 leading-relaxed">
                     {exp.description}
                   </p>
+
+                  {/* Bullets */}
+                  <ul className="space-y-1 mb-4">
+                    {exp.bullets.slice(0, 3).map((bullet, i) => (
+                      <li key={i} className="text-sm text-muted-foreground/80 flex items-start gap-2">
+                        <span className="text-primary mt-1.5 text-xs">&#9679;</span>
+                        {bullet}
+                      </li>
+                    ))}
+                  </ul>
+
+                  {/* Tech Stack */}
+                  <div className="flex flex-wrap gap-2">
+                    {exp.techStack.map((tech) => (
+                      <span key={tech} className="tech-pill">
+                        {tech}
+                      </span>
+                    ))}
+                  </div>
                 </div>
               </div>
             ))}
-          </div>
-          
-          {/* Illustration */}
-          <div className="hidden lg:block">
-            <img 
-              src={serversIllustration} 
-              alt="Server infrastructure" 
-              className="w-full h-auto rounded-2xl shadow-card"
-            />
           </div>
         </div>
       </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,45 +1,45 @@
-import { Linkedin, Mail, Globe } from "lucide-react";
+import { Linkedin, Github, Mail } from "lucide-react";
+import { personalInfo } from "@/data/resume";
 
 const Footer = () => {
   return (
-    <footer className="py-12 bg-card border-t border-border">
+    <footer className="py-8 bg-background border-t border-border">
       <div className="section-container">
-        <div className="flex flex-col md:flex-row items-center justify-between gap-6">
-          {/* Name */}
-          <div className="font-serif text-2xl font-bold text-foreground">
-            Ali Yildiz
-          </div>
-          
-          {/* Social Links */}
-          <div className="flex items-center gap-6">
-            <a 
-              href="https://linkedin.com/in/yildizalicom" 
-              target="_blank" 
+        <div className="flex flex-col md:flex-row items-center justify-between gap-4">
+          <p className="text-sm text-muted-foreground font-mono">
+            {personalInfo.fullName}
+          </p>
+
+          <div className="flex items-center gap-5">
+            <a
+              href={`https://${personalInfo.linkedin}`}
+              target="_blank"
               rel="noopener noreferrer"
               className="text-muted-foreground hover:text-primary transition-colors"
               aria-label="LinkedIn"
             >
-              <Linkedin className="w-6 h-6" />
+              <Linkedin className="w-5 h-5" />
             </a>
-            <a 
-              href="#" 
+            <a
+              href={`https://${personalInfo.github}`}
+              target="_blank"
+              rel="noopener noreferrer"
               className="text-muted-foreground hover:text-primary transition-colors"
-              aria-label="Website"
+              aria-label="GitHub"
             >
-              <Globe className="w-6 h-6" />
+              <Github className="w-5 h-5" />
             </a>
-            <a 
-              href="mailto:" 
+            <a
+              href={`mailto:${personalInfo.email}`}
               className="text-muted-foreground hover:text-primary transition-colors"
               aria-label="Email"
             >
-              <Mail className="w-6 h-6" />
+              <Mail className="w-5 h-5" />
             </a>
           </div>
-          
-          {/* Copyright */}
-          <p className="text-muted-foreground text-sm">
-            © {new Date().getFullYear()} All rights reserved.
+
+          <p className="text-sm text-muted-foreground">
+            &copy; {new Date().getFullYear()} All rights reserved.
           </p>
         </div>
       </div>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,60 +1,59 @@
-import { Linkedin, Globe } from "lucide-react";
-import heroIllustration from "@/assets/hero-illustration.png";
+import { ArrowDown, Mail } from "lucide-react";
+import { personalInfo } from "@/data/resume";
 
 const HeroSection = () => {
   return (
-    <section className="relative min-h-screen flex items-center overflow-hidden" style={{ background: 'var(--gradient-hero)' }}>
-      {/* Background illustration */}
-      <div className="absolute right-0 top-1/2 -translate-y-1/2 w-1/2 h-full opacity-30 pointer-events-none">
-        <img 
-          src={heroIllustration} 
-          alt="Data engineer workspace" 
-          className="w-full h-full object-contain object-right"
-        />
-      </div>
-      
+    <section
+      className="relative min-h-screen flex items-center overflow-hidden"
+      style={{ background: 'var(--gradient-hero)' }}
+    >
+      {/* Subtle grid background */}
+      <div className="absolute inset-0 opacity-[0.03]" style={{
+        backgroundImage: 'linear-gradient(hsl(270 60% 62%) 1px, transparent 1px), linear-gradient(90deg, hsl(270 60% 62%) 1px, transparent 1px)',
+        backgroundSize: '60px 60px',
+      }} />
+
       <div className="section-container relative z-10 py-20">
-        <div className="max-w-2xl">
+        <div className="max-w-3xl">
           {/* Badge */}
           <div className="inline-block mb-6 animate-fade-up" style={{ animationDelay: '0.1s' }}>
-            <span className="px-4 py-2 rounded-full bg-primary/10 text-primary text-sm font-medium">
-              Senior Data Engineer
+            <span className="px-4 py-2 rounded-full bg-primary/10 text-primary text-sm font-medium border border-primary/20">
+              {personalInfo.title}
             </span>
           </div>
-          
-          {/* Location */}
-          <p className="text-muted-foreground mb-4 animate-fade-up" style={{ animationDelay: '0.2s' }}>
-            Amsterdam, Netherlands
-          </p>
-          
-          {/* Name */}
-          <h1 className="font-serif text-5xl md:text-6xl lg:text-7xl font-bold text-foreground mb-6 animate-fade-up" style={{ animationDelay: '0.3s' }}>
-            Ali Yildiz, MSc
+
+          {/* Headline */}
+          <h1 className="text-5xl md:text-6xl lg:text-7xl font-bold text-foreground mb-6 animate-fade-up leading-tight" style={{ animationDelay: '0.2s' }}>
+            Engineering Data,{' '}
+            <span className="text-gradient">End to End</span>
           </h1>
-          
+
           {/* Tagline */}
-          <p className="text-lg md:text-xl text-muted-foreground leading-relaxed mb-10 animate-fade-up" style={{ animationDelay: '0.4s' }}>
-            Building Scalable ML & Big Data Pipelines | Transforming data into actionable insights with cutting-edge technologies
+          <p className="text-lg md:text-xl text-muted-foreground leading-relaxed mb-10 max-w-2xl animate-fade-up" style={{ animationDelay: '0.3s' }}>
+            Senior Data Engineer & Cloud Architect — building scalable pipelines across GCP, AWS, and Azure
           </p>
-          
+
           {/* CTA Buttons */}
-          <div className="flex flex-wrap gap-4 animate-fade-up" style={{ animationDelay: '0.5s' }}>
-            <a 
-              href="https://linkedin.com/in/yildizalicom" 
-              target="_blank" 
-              rel="noopener noreferrer"
+          <div className="flex flex-wrap gap-4 animate-fade-up" style={{ animationDelay: '0.4s' }}>
+            <a
+              href="#experience"
               className="btn-primary inline-flex items-center gap-2"
             >
-              <Linkedin className="w-5 h-5" />
-              Connect on LinkedIn
+              <ArrowDown className="w-4 h-4" />
+              View Experience
             </a>
-            <a 
-              href="#" 
+            <a
+              href="#contact"
               className="btn-outline inline-flex items-center gap-2"
             >
-              <Globe className="w-5 h-5" />
-              Visit Website
+              <Mail className="w-4 h-4" />
+              Get in Touch
             </a>
+          </div>
+
+          {/* Name */}
+          <div className="mt-16 animate-fade-up" style={{ animationDelay: '0.5s' }}>
+            <p className="text-sm text-muted-foreground font-mono">{personalInfo.fullName}</p>
           </div>
         </div>
       </div>

--- a/src/components/SkillsSection.tsx
+++ b/src/components/SkillsSection.tsx
@@ -1,117 +1,73 @@
-import { Code, Cloud, Radio, Database, GraduationCap, Award } from "lucide-react";
+import { Code, Cloud, Database, Settings, Award } from "lucide-react";
+import { skills, certifications } from "@/data/resume";
 
-interface SkillCategory {
-  icon: React.ReactNode;
-  title: string;
-  items: string[];
-}
-
-const skillCategories: SkillCategory[] = [
-  {
-    icon: <Code className="w-5 h-5" />,
-    title: "Languages",
-    items: ["Spark", "Scala", "Python", "Java"]
-  },
-  {
-    icon: <Cloud className="w-5 h-5" />,
-    title: "Cloud",
-    items: ["GCP", "AWS", "Azure", "OpenShift"]
-  },
-  {
-    icon: <Radio className="w-5 h-5" />,
-    title: "Streaming",
-    items: ["Kafka", "NiFi", "Airflow"]
-  },
-  {
-    icon: <Database className="w-5 h-5" />,
-    title: "Databases",
-    items: ["Oracle", "SQL Server", "MongoDB", "TimescaleDB"]
-  }
-];
-
-const credentials = [
-  {
-    icon: <GraduationCap className="w-6 h-6" />,
-    title: "MSc Computer Engineering",
-    subtitle: "Data Mining Focus"
-  },
-  {
-    icon: <Award className="w-6 h-6" />,
-    title: "Databricks Certified",
-    subtitle: "Data Engineer Professional"
-  },
-  {
-    icon: <Award className="w-6 h-6" />,
-    title: "Soda Certified",
-    subtitle: "Cloud Fundamentals"
-  }
-];
+const categoryIcons: Record<string, React.ReactNode> = {
+  Programming: <Code className="w-5 h-5" />,
+  'Data Stack': <Database className="w-5 h-5" />,
+  Cloud: <Cloud className="w-5 h-5" />,
+  Tech: <Settings className="w-5 h-5" />,
+};
 
 const SkillsSection = () => {
   return (
-    <section className="py-24 bg-background">
+    <section id="skills" className="py-24 bg-card">
       <div className="section-container">
         {/* Section Header */}
         <div className="text-center mb-16">
-          <h2 className="font-serif text-4xl md:text-5xl font-bold text-foreground mb-4">
-            Technical Expertise & Credentials
+          <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
+            Technical Skills
           </h2>
+          <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
+            Full-stack data engineer across all three major cloud platforms.
+          </p>
         </div>
-        
-        {/* Two Column Layout */}
-        <div className="grid md:grid-cols-2 gap-12">
-          {/* Core Skills */}
-          <div className="card-soft">
-            <h3 className="font-serif text-2xl font-semibold text-foreground mb-8">
-              Core Skills
-            </h3>
-            
-            <div className="space-y-6">
-              {skillCategories.map((category, index) => (
-                <div 
-                  key={category.title}
-                  className="animate-fade-up"
-                  style={{ animationDelay: `${index * 0.1}s` }}
-                >
-                  <div className="flex items-center gap-2 mb-3">
-                    <span className="text-primary">{category.icon}</span>
-                    <span className="font-semibold text-foreground">{category.title}</span>
-                  </div>
-                  <div className="flex flex-wrap gap-2">
-                    {category.items.map((item) => (
-                      <span key={item} className="skill-tag">
-                        {item}
-                      </span>
-                    ))}
-                  </div>
-                </div>
-              ))}
+
+        {/* Skills Grid */}
+        <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-6 mb-16">
+          {skills.map((category, index) => (
+            <div
+              key={category.category}
+              className="card-soft animate-fade-up"
+              style={{ animationDelay: `${index * 0.1}s` }}
+            >
+              <div className="flex items-center gap-3 mb-4">
+                <span className="text-primary">
+                  {categoryIcons[category.category] || <Code className="w-5 h-5" />}
+                </span>
+                <h3 className="font-bold text-foreground">{category.category}</h3>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {category.skills.map((skill) => (
+                  <span key={skill} className="skill-tag text-xs">
+                    {skill}
+                  </span>
+                ))}
+              </div>
             </div>
-          </div>
-          
-          {/* Education & Certifications */}
-          <div className="card-soft">
-            <h3 className="font-serif text-2xl font-semibold text-foreground mb-8">
-              Education & Certifications
-            </h3>
-            
-            <div className="space-y-6">
-              {credentials.map((cred, index) => (
-                <div 
-                  key={cred.title}
-                  className="flex items-start gap-4 p-4 rounded-xl bg-background/50 animate-fade-up"
-                  style={{ animationDelay: `${index * 0.1}s` }}
-                >
-                  <div className="flex-shrink-0 w-12 h-12 rounded-full bg-primary/10 flex items-center justify-center text-primary">
-                    {cred.icon}
-                  </div>
-                  <div>
-                    <h4 className="font-semibold text-foreground">{cred.title}</h4>
-                    <p className="text-muted-foreground text-sm">{cred.subtitle}</p>
-                  </div>
+          ))}
+        </div>
+
+        {/* Certifications */}
+        <div className="max-w-2xl mx-auto">
+          <h3 className="text-xl font-bold text-foreground text-center mb-6">
+            Certifications
+          </h3>
+          <div className="grid sm:grid-cols-2 gap-4">
+            {certifications.map((cert, index) => (
+              <div
+                key={cert.name}
+                className="flex items-center gap-4 p-4 rounded-xl bg-background border border-border animate-fade-up"
+                style={{ animationDelay: `${index * 0.1}s` }}
+              >
+                <div className="flex-shrink-0 w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center">
+                  <Award className="w-5 h-5 text-primary" />
                 </div>
-              ))}
-            </div>
+                <div>
+                  <p className="font-medium text-foreground text-sm">{cert.name}</p>
+                  <p className="text-muted-foreground text-xs font-mono">{cert.date}</p>
+                </div>
+              </div>
+            ))}
           </div>
         </div>
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;500;600;700&family=Inter:wght@300;400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
 
 @tailwind base;
 @tailwind components;
@@ -6,95 +6,55 @@
 
 @layer base {
   :root {
-    --background: 40 33% 97%;
-    --foreground: 195 40% 20%;
+    --background: 240 15% 9%;
+    --foreground: 240 10% 93%;
 
-    --card: 40 30% 95%;
-    --card-foreground: 195 40% 20%;
+    --card: 240 14% 12%;
+    --card-foreground: 240 10% 93%;
 
-    --popover: 40 33% 97%;
-    --popover-foreground: 195 40% 20%;
+    --popover: 240 14% 12%;
+    --popover-foreground: 240 10% 93%;
 
-    --primary: 183 40% 40%;
-    --primary-foreground: 40 33% 97%;
+    --primary: 270 60% 62%;
+    --primary-foreground: 240 15% 9%;
 
-    --secondary: 350 30% 92%;
-    --secondary-foreground: 195 40% 20%;
+    --secondary: 240 12% 16%;
+    --secondary-foreground: 240 10% 93%;
 
-    --muted: 40 20% 90%;
-    --muted-foreground: 195 20% 45%;
+    --muted: 240 12% 16%;
+    --muted-foreground: 240 10% 60%;
 
-    --accent: 350 35% 85%;
-    --accent-foreground: 195 40% 20%;
+    --accent: 270 40% 20%;
+    --accent-foreground: 240 10% 93%;
 
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 210 40% 98%;
 
-    --border: 40 20% 85%;
-    --input: 40 20% 85%;
-    --ring: 183 40% 40%;
+    --border: 240 12% 18%;
+    --input: 240 12% 18%;
+    --ring: 270 60% 62%;
 
     --radius: 0.75rem;
 
-    /* Custom tokens */
-    --teal: 183 40% 40%;
-    --teal-light: 183 35% 55%;
-    --teal-dark: 183 45% 30%;
-    --cream: 40 33% 97%;
-    --cream-dark: 40 25% 92%;
-    --blush: 350 35% 90%;
-    --sage: 150 20% 85%;
+    --gradient-hero: linear-gradient(135deg, hsl(240 15% 9%) 0%, hsl(270 30% 12%) 50%, hsl(240 15% 9%) 100%);
+    --gradient-card: linear-gradient(180deg, hsl(240 14% 13%) 0%, hsl(240 14% 11%) 100%);
+    --gradient-purple: linear-gradient(135deg, hsl(270 60% 62%) 0%, hsl(280 50% 50%) 100%);
 
-    /* Gradients */
-    --gradient-hero: linear-gradient(135deg, hsl(40 33% 97%) 0%, hsl(350 35% 95%) 50%, hsl(40 30% 95%) 100%);
-    --gradient-card: linear-gradient(180deg, hsl(40 30% 96%) 0%, hsl(40 25% 93%) 100%);
-    --gradient-teal: linear-gradient(135deg, hsl(183 40% 40%) 0%, hsl(183 35% 50%) 100%);
+    --shadow-soft: 0 4px 20px -4px hsl(0 0% 0% / 0.3);
+    --shadow-card: 0 8px 30px -8px hsl(0 0% 0% / 0.4);
+    --shadow-button: 0 4px 14px -3px hsl(270 60% 62% / 0.4);
 
-    /* Shadows */
-    --shadow-soft: 0 4px 20px -4px hsl(195 40% 20% / 0.08);
-    --shadow-card: 0 8px 30px -8px hsl(195 40% 20% / 0.1);
-    --shadow-button: 0 4px 14px -3px hsl(183 40% 40% / 0.4);
-
-    /* Typography */
-    --font-serif: 'Playfair Display', serif;
     --font-sans: 'Inter', system-ui, sans-serif;
+    --font-mono: 'JetBrains Mono', monospace;
 
-    --sidebar-background: 0 0% 98%;
-    --sidebar-foreground: 240 5.3% 26.1%;
-    --sidebar-primary: 240 5.9% 10%;
-    --sidebar-primary-foreground: 0 0% 98%;
-    --sidebar-accent: 240 4.8% 95.9%;
-    --sidebar-accent-foreground: 240 5.9% 10%;
-    --sidebar-border: 220 13% 91%;
-    --sidebar-ring: 217.2 91.2% 59.8%;
-  }
-
-  .dark {
-    --background: 195 40% 10%;
-    --foreground: 40 33% 95%;
-    --card: 195 35% 15%;
-    --card-foreground: 40 33% 95%;
-    --popover: 195 40% 10%;
-    --popover-foreground: 40 33% 95%;
-    --primary: 183 45% 50%;
-    --primary-foreground: 195 40% 10%;
-    --secondary: 195 30% 20%;
-    --secondary-foreground: 40 33% 95%;
-    --muted: 195 25% 20%;
-    --muted-foreground: 40 20% 70%;
-    --accent: 350 25% 25%;
-    --accent-foreground: 40 33% 95%;
-    --border: 195 25% 25%;
-    --input: 195 25% 25%;
-    --ring: 183 45% 50%;
-    --sidebar-background: 240 5.9% 10%;
-    --sidebar-foreground: 240 4.8% 95.9%;
-    --sidebar-primary: 224.3 76.3% 48%;
-    --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 240 3.7% 15.9%;
-    --sidebar-accent-foreground: 240 4.8% 95.9%;
-    --sidebar-border: 240 3.7% 15.9%;
-    --sidebar-ring: 217.2 91.2% 59.8%;
+    --sidebar-background: 240 15% 9%;
+    --sidebar-foreground: 240 10% 93%;
+    --sidebar-primary: 270 60% 62%;
+    --sidebar-primary-foreground: 240 15% 9%;
+    --sidebar-accent: 240 12% 16%;
+    --sidebar-accent-foreground: 240 10% 93%;
+    --sidebar-border: 240 12% 18%;
+    --sidebar-ring: 270 60% 62%;
   }
 }
 
@@ -103,32 +63,37 @@
     @apply border-border;
   }
 
+  html {
+    scroll-behavior: smooth;
+  }
+
   body {
     @apply bg-background text-foreground font-sans antialiased;
     font-family: var(--font-sans);
   }
 
   h1, h2, h3, h4, h5, h6 {
-    font-family: var(--font-serif);
+    font-family: var(--font-sans);
+    @apply font-bold tracking-tight;
   }
 }
 
 @layer components {
   .btn-primary {
-    @apply bg-primary text-primary-foreground px-6 py-3 rounded-lg font-medium 
+    @apply bg-primary text-primary-foreground px-6 py-3 rounded-lg font-medium
            transition-all duration-300 hover:opacity-90;
     box-shadow: var(--shadow-button);
   }
 
   .btn-outline {
-    @apply bg-transparent border-2 border-primary text-primary px-6 py-3 rounded-lg font-medium
-           transition-all duration-300 hover:bg-primary hover:text-primary-foreground;
+    @apply bg-transparent border border-primary/50 text-primary px-6 py-3 rounded-lg font-medium
+           transition-all duration-300 hover:bg-primary/10;
   }
 
   .card-soft {
     background: var(--gradient-card);
     box-shadow: var(--shadow-card);
-    @apply rounded-2xl p-6;
+    @apply rounded-2xl p-6 border border-border;
   }
 
   .section-container {
@@ -136,31 +101,24 @@
   }
 
   .text-gradient {
-    background: var(--gradient-teal);
+    background: var(--gradient-purple);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;
   }
 
-  .number-badge {
-    @apply w-10 h-10 rounded-full bg-primary text-primary-foreground 
-           flex items-center justify-center font-bold text-lg;
+  .tech-pill {
+    @apply px-3 py-1 rounded-full text-xs font-medium bg-primary/10 text-primary border border-primary/20;
   }
 
   .skill-tag {
-    @apply px-4 py-2 rounded-full text-sm font-medium;
-    background: hsl(var(--cream-dark));
-    color: hsl(var(--foreground));
+    @apply px-4 py-2 rounded-full text-sm font-medium bg-secondary text-foreground border border-border;
   }
 }
 
 @layer utilities {
-  .font-serif {
-    font-family: var(--font-serif);
-  }
-
-  .font-sans {
-    font-family: var(--font-sans);
+  .font-mono {
+    font-family: var(--font-mono);
   }
 
   .animate-fade-up {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,16 +1,20 @@
 import HeroSection from "@/components/HeroSection";
+import AboutSection from "@/components/AboutSection";
 import ExperienceSection from "@/components/ExperienceSection";
 import SkillsSection from "@/components/SkillsSection";
-import MetricsSection from "@/components/MetricsSection";
+import EducationSection from "@/components/EducationSection";
+import ContactSection from "@/components/ContactSection";
 import Footer from "@/components/Footer";
 
 const Index = () => {
   return (
     <main className="min-h-screen">
       <HeroSection />
+      <AboutSection />
       <ExperienceSection />
       <SkillsSection />
-      <MetricsSection />
+      <EducationSection />
+      <ContactSection />
       <Footer />
     </main>
   );

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -57,21 +57,10 @@ export default {
           border: "hsl(var(--sidebar-border))",
           ring: "hsl(var(--sidebar-ring))",
         },
-        teal: {
-          DEFAULT: "hsl(var(--teal))",
-          light: "hsl(var(--teal-light))",
-          dark: "hsl(var(--teal-dark))",
-        },
-        cream: {
-          DEFAULT: "hsl(var(--cream))",
-          dark: "hsl(var(--cream-dark))",
-        },
-        blush: "hsl(var(--blush))",
-        sage: "hsl(var(--sage))",
       },
       fontFamily: {
-        serif: ['Playfair Display', 'serif'],
         sans: ['Inter', 'system-ui', 'sans-serif'],
+        mono: ['JetBrains Mono', 'monospace'],
       },
       borderRadius: {
         lg: "var(--radius)",
@@ -103,9 +92,9 @@ export default {
         "fade-in": "fade-in 0.8s ease-out forwards",
       },
       boxShadow: {
-        soft: "0 4px 20px -4px hsl(195 40% 20% / 0.08)",
-        card: "0 8px 30px -8px hsl(195 40% 20% / 0.1)",
-        button: "0 4px 14px -3px hsl(183 40% 40% / 0.4)",
+        soft: "0 4px 20px -4px hsl(0 0% 0% / 0.3)",
+        card: "0 8px 30px -8px hsl(0 0% 0% / 0.4)",
+        button: "0 4px 14px -3px hsl(270 60% 62% / 0.4)",
       },
     },
   },


### PR DESCRIPTION
## Summary

- Rebuilt the entire website based on `docs/content-strategy.md`
- Dark theme with deep purple accent, Inter + JetBrains Mono fonts
- All components import data from `src/data/resume.ts` — no hardcoded personal data

## Components Created/Modified

| Component | Status | Description |
|-----------|--------|-------------|
| `HeroSection` | Modified | "Engineering Data, End to End" headline, CTA buttons |
| `AboutSection` | **New** | Summary + biography from resume data |
| `ExperienceSection` | Modified | Timeline layout, all 9 roles with tech stack pills |
| `SkillsSection` | Modified | 4-category grid, certifications embedded |
| `EducationSection` | **New** | Compact education entries + languages |
| `ContactSection` | **New** | Email, LinkedIn, GitHub with CTA |
| `Footer` | Modified | Minimal footer with social links |
| `MetricsSection` | Removed | Not in content strategy |

## Section Order (scroll sequence)

1. Hero
2. About
3. Experience
4. Skills (with Certifications)
5. Education
6. Contact
7. Footer

## Styling Changes

- `src/index.css` — Dark theme variables, purple accent (hsl 270 60% 62%), removed old teal/cream tokens
- `tailwind.config.ts` — Updated font families, box shadows, removed old color tokens

## Verification

- `npm run build` — passes
- `npx tsc --noEmit` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)