### PR TITLE
feat: update resume content and privacy

### DIFF
--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -1,5 +1,4 @@
-import { Mail, Linkedin, Github } from "lucide-react";
-import { personalInfo } from "@/data/resume";
+import { Linkedin } from "lucide-react";
 
 const ContactSection = () => {
   return (
@@ -9,43 +8,16 @@ const ContactSection = () => {
           <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
             Let's Build Something Together
           </h2>
-          <p className="text-lg text-muted-foreground mb-10">
-            Open to new opportunities and interesting data challenges.
-          </p>
 
-          <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
-            <a
-              href={`mailto:${personalInfo.email}`}
-              className="btn-primary inline-flex items-center gap-2 w-full sm:w-auto justify-center"
-            >
-              <Mail className="w-4 h-4" />
-              {personalInfo.email}
-            </a>
-            <a
-              href={`https://${personalInfo.linkedin}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="btn-outline inline-flex items-center gap-2 w-full sm:w-auto justify-center"
-            >
-              <Linkedin className="w-4 h-4" />
-              LinkedIn
-            </a>
-            <a
-              href={`https://${personalInfo.github}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="btn-outline inline-flex items-center gap-2 w-full sm:w-auto justify-center"
-            >
-              <Github className="w-4 h-4" />
-              GitHub
-            </a>
-          </div>
-
-          {personalInfo.phone && (
-            <p className="mt-6 text-sm text-muted-foreground font-mono">
-              {personalInfo.phone}
-            </p>
-          )}
+          <a
+            href="https://www.linkedin.com/in/yildizalicom"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="btn-primary inline-flex items-center gap-2"
+          >
+            <Linkedin className="w-4 h-4" />
+            Connect on LinkedIn
+          </a>
         </div>
       </div>
     </section>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,4 +1,4 @@
-import { Linkedin, Github, Mail } from "lucide-react";
+import { Linkedin } from "lucide-react";
 import { personalInfo } from "@/data/resume";
 
 const Footer = () => {
@@ -10,33 +10,15 @@ const Footer = () => {
             {personalInfo.fullName}
           </p>
 
-          <div className="flex items-center gap-5">
-            <a
-              href={`https://${personalInfo.linkedin}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-muted-foreground hover:text-primary transition-colors"
-              aria-label="LinkedIn"
-            >
-              <Linkedin className="w-5 h-5" />
-            </a>
-            <a
-              href={`https://${personalInfo.github}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-muted-foreground hover:text-primary transition-colors"
-              aria-label="GitHub"
-            >
-              <Github className="w-5 h-5" />
-            </a>
-            <a
-              href={`mailto:${personalInfo.email}`}
-              className="text-muted-foreground hover:text-primary transition-colors"
-              aria-label="Email"
-            >
-              <Mail className="w-5 h-5" />
-            </a>
-          </div>
+          <a
+            href="https://www.linkedin.com/in/yildizalicom"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-muted-foreground hover:text-primary transition-colors"
+            aria-label="LinkedIn"
+          >
+            <Linkedin className="w-5 h-5" />
+          </a>
 
           <p className="text-sm text-muted-foreground">
             &copy; {new Date().getFullYear()} All rights reserved.

--- a/src/data/resume.ts
+++ b/src/data/resume.ts
@@ -103,6 +103,22 @@ export const languages: Language[] = [
 
 export const experiences: Experience[] = [
   {
+    title: 'Data Platform Engineer / Senior Data Engineer',
+    company: 'NIBC',
+    startDate: '2025 March',
+    endDate: 'Present',
+    description:
+      'Worked on developing new features for the cloud data platform and strengthening the system from a security perspective.',
+    bullets: [
+      'Implemented Soda Core and Soda Cloud as the data quality solution for the platform.',
+      'Helped expand the data platform\'s architectural design through several Architectural Decision Records (ADRs).',
+      'Deployed and maintained infrastructure on Azure using Terraform, including Azure Data Factory, dbt Cloud, Function Apps, Databricks, and networking components.',
+      'Developed a set of best practices and standards for proper platform usage.',
+      'Actively contributed as an individual contributor while also guiding and supporting fellow Data Engineers in delivering work in accordance with established standards.',
+    ],
+    techStack: ['Azure', 'Terraform', 'Databricks', 'dbt Cloud', 'Soda Core', 'Azure Data Factory'],
+  },
+  {
     title: 'Senior Data Engineer',
     company: 'Irish Rail - Iarnród Éireann',
     startDate: '2024 December',
@@ -169,7 +185,7 @@ export const experiences: Experience[] = [
     techStack: ['GCP', 'BigQuery', 'DBT Cloud', 'Preset.io', 'GitHub'],
   },
   {
-    title: 'Data Engineer',
+    title: 'Senior Data Engineer',
     company: 'International Flavors & Fragrances Inc.',
     startDate: '2022 November',
     endDate: '2023 February',
@@ -183,7 +199,7 @@ export const experiences: Experience[] = [
     techStack: ['AWS', 'Sagemaker', 'MLOps', 'Terraform', 'Jenkins'],
   },
   {
-    title: 'Big Data Engineer / Cloud Data Architect',
+    title: 'Senior Data Engineer',
     company: 'Coca Cola İçecek',
     startDate: '2021 August',
     endDate: '2022 November',
@@ -207,7 +223,7 @@ export const experiences: Experience[] = [
     ],
   },
   {
-    title: 'Expert Big Data Engineer',
+    title: 'Senior Data Engineer',
     company: 'GarantiBBVA Technology',
     startDate: '2015 November',
     endDate: '2021 August',
@@ -235,7 +251,7 @@ export const experiences: Experience[] = [
     ],
   },
   {
-    title: 'Senior Software Specialist',
+    title: 'Senior Data Engineer',
     company: 'IBTech Technology',
     startDate: '2012 September',
     endDate: '2015 October',
@@ -250,7 +266,7 @@ export const experiences: Experience[] = [
     techStack: ['SAP DS', 'MicroStrategy', 'ODI', 'OBI', 'Oracle Exadata'],
   },
   {
-    title: 'Software Developer',
+    title: 'Senior Data Engineer',
     company: 'BIS Çözüm',
     startDate: '2012 April',
     endDate: '2012 September',


### PR DESCRIPTION
## Summary

- Add NIBC as most recent experience (March 2025 – Present)
- Update job titles to "Senior Data Engineer" from IFF onwards
- Remove email, phone, and GitHub from website — only LinkedIn visible
- Remove "Open to opportunities" text from Contact section

## Test plan

- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)