### PR TITLE
ci: open issue on validate failure for email alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,51 @@ jobs:
         run: npm run lint
       - name: Build
         run: npm run build
+
+  notify-on-failure:
+    needs: validate
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update CI failure issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const isPR = context.eventName === 'pull_request';
+            const pr = context.payload.pull_request;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const sha = context.sha.substring(0, 7);
+            const titlePrefix = isPR ? `CI failure on PR #${pr.number}` : `CI failure on main`;
+            const body = [
+              isPR ? `\`validate\` failed on **PR #${pr.number}** — _${pr.title}_` : `\`validate\` failed on push to **main**.`,
+              '',
+              `- Run: ${runUrl}`,
+              `- Commit: \`${sha}\``,
+              isPR ? `- PR: ${pr.html_url}` : '',
+            ].filter(Boolean).join('\n');
+
+            const { data: openIssues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+            const match = openIssues.find((i) => !i.pull_request && i.title.startsWith(titlePrefix));
+
+            if (match) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: match.number,
+                body: `Another failure:\n\n${body}`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: `${titlePrefix}: ${sha}`,
+                body,
+              });
+            }


### PR DESCRIPTION
## Summary
- Adds a `notify-on-failure` job to [ci.yml](.github/workflows/ci.yml) that runs only when `validate` fails.
- Opens a GitHub issue describing the failure (PR/commit/run link). If an open issue already exists for the same PR (or for main), adds a comment instead of opening a duplicate.
- Repo watchers (you) will get an email for each new issue / new comment.

## Why
When a Renovate PR's CI fails, automerge can't happen — but you wanted explicit email notice instead of having to monitor PRs manually. Issue subscriptions guarantee email, and the issue body keeps the failure context.

## Test plan
- [ ] PR's own CI passes (the new job only runs on failure, so on green this PR it should be skipped — visible as a skipped job).
- [ ] After merge, intentionally break the build on a throwaway branch and open a PR; verify a new issue is opened and you receive an email.
- [ ] Push another bad commit to the same PR; verify the existing issue gets a new comment instead of a new issue being opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)