### PR TITLE
fix(deps): bump flatted to 3.4.2 to resolve npm audit advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3326,11 +3326,10 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
-      "dev": true,
-      "license": "ISC"
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true
     },
     "node_modules/fraction.js": {
       "version": "5.3.4",


### PR DESCRIPTION
## Summary
- Lockfile-only bump of `flatted` 3.3.1 → 3.4.2.
- Resolves the only `npm audit` finding (high severity): prototype pollution + unbounded recursion DoS in `flatted.parse()`.
- Transitive dep via `eslint -> file-entry-cache -> flat-cache -> flatted`. Devtime only — does not ship to the production site.

## Test plan
- [ ] CI `validate` (lint + build) passes.
- [ ] After merge: `npm audit` reports 0 vulnerabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)