### PR TITLE
chore(renovate): disable Dependency Dashboard issue

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,5 +20,6 @@
   "automerge": true,
   "automergeType": "pr",
   "automergeStrategy": "squash",
-  "platformAutomerge": true
+  "platformAutomerge": true,
+  "dependencyDashboard": false
 }


### PR DESCRIPTION
## Summary
- Add \`dependencyDashboard: false\` to [renovate.json](renovate.json).
- Stops Renovate from creating/updating the Dependency Dashboard issue (#14) and the email noise it generates whenever Renovate scans state.
- We don't need its manual trigger checkboxes since automerge handles everything end-to-end.

## Test plan
- [ ] CI passes.
- [ ] After merge: issue #14 should stay closed (Renovate will close it on next run since dashboard is disabled).
- [ ] Future Renovate dependency PRs continue to open and automerge as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)