### PR TITLE
chore: a11y aria-label + JSON-LD Person schema

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,30 @@
     <meta name="twitter:title" content="Ali Yildiz, MSc | Senior Data Engineer" />
     <meta name="twitter:description" content="Building Scalable ML & Big Data Pipelines with 14+ years of experience" />
     <meta name="twitter:image" content="https://www.yildizali.com/og-image.jpeg" />
+
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Person",
+        "name": "Ali Yildiz",
+        "jobTitle": "Senior Data and Platform Engineer",
+        "url": "https://www.yildizali.com",
+        "image": "https://www.yildizali.com/og-image.jpeg",
+        "sameAs": [
+          "https://www.linkedin.com/in/yildizalicom"
+        ],
+        "worksFor": {
+          "@type": "Organization",
+          "name": "Xebia B.V.",
+          "url": "https://www.xebia.com"
+        },
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Amsterdam",
+          "addressCountry": "NL"
+        }
+      }
+    </script>
   </head>
 
   <body>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -78,6 +78,7 @@ const HeroSection = () => {
                 href="https://www.linkedin.com/in/yildizalicom"
                 target="_blank"
                 rel="noopener noreferrer"
+                aria-label="Connect with Ali Yildiz on LinkedIn"
                 className="btn-outline inline-flex items-center gap-2"
               >
                 <Linkedin className="w-4 h-4" />


### PR DESCRIPTION
## Summary
Two small SEO/a11y improvements from the site review:

- **A11y** — [HeroSection.tsx](src/components/HeroSection.tsx) the 'Connect' LinkedIn link only had the word 'Connect' as accessible text. Added \`aria-label=\"Connect with Ali Yildiz on LinkedIn\"\` so screen-reader users hear the destination.
- **SEO** — [index.html](index.html) now embeds a schema.org \`Person\` JSON-LD block (name, jobTitle, url, image, sameAs LinkedIn, worksFor Xebia, addressLocality Amsterdam). Helps Google associate the page with the person entity and may surface a knowledge panel.

## Skipped from the review
- **Heading hierarchy in HeroSection** — h1 followed by h2 is structurally fine; the subagent's flag was overly pedantic.
- **Responsive breakpoint coverage (xl: variants)** — visual change; needs designer review before bulk-adding breakpoints.

## Test plan
- [ ] CI passes.
- [ ] After deploy: paste site URL into [Google's Rich Results Test](https://search.google.com/test/rich-results) — JSON-LD validates as Person.
- [ ] Inspect HeroSection LinkedIn link with browser devtools accessibility panel — accessible name reads the full label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)