### PR TITLE
refactor: derive years-of-experience once in resume.ts

### DIFF
--- a/src/components/ExperienceSection.tsx
+++ b/src/components/ExperienceSection.tsx
@@ -1,5 +1,5 @@
 import { Briefcase } from "lucide-react";
-import { experiences } from "@/data/resume";
+import { experiences, yearsOfExperience } from "@/data/resume";
 
 const ExperienceSection = () => {
   return (
@@ -11,7 +11,7 @@ const ExperienceSection = () => {
             Professional Experience
           </h2>
           <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
-            14+ years spanning software development, data engineering, and cloud architecture across major enterprises.
+            {yearsOfExperience}+ years spanning software development, data engineering, and cloud architecture across major enterprises.
           </p>
         </div>
 

--- a/src/components/MetricsSection.tsx
+++ b/src/components/MetricsSection.tsx
@@ -1,13 +1,7 @@
-import { experiences, certifications } from "@/data/resume";
-
-const earliestYear = parseInt(
-  experiences[experiences.length - 1].startDate.split(" ")[0],
-  10,
-);
-const yearsExperience = new Date().getFullYear() - earliestYear;
+import { yearsOfExperience, certifications } from "@/data/resume";
 
 const metrics = [
-  { value: `${yearsExperience}+`, label: "Years Experience" },
+  { value: `${yearsOfExperience}+`, label: "Years Experience" },
   { value: `${certifications.length}+`, label: "Certifications" },
   { value: "3", label: "Cloud Platforms" },
 ];

--- a/src/data/resume.ts
+++ b/src/data/resume.ts
@@ -284,3 +284,11 @@ export const experiences: Experience[] = [
     techStack: ['C#', 'ASP.NET', 'SQL Server', 'T-SQL'],
   },
 ];
+
+const earliestExperienceYear = parseInt(
+  experiences[experiences.length - 1].startDate.split(' ')[0],
+  10,
+);
+
+export const yearsOfExperience =
+  new Date().getFullYear() - earliestExperienceYear;


### PR DESCRIPTION
## Summary
- New export \`yearsOfExperience\` in [src/data/resume.ts](src/data/resume.ts), computed at module-load time as \`currentYear − earliestExperienceStartYear\`. Single source of truth.
- [ExperienceSection.tsx:14](src/components/ExperienceSection.tsx#L14) renders \`{yearsOfExperience}+\` instead of the hardcoded literal — auto-updates each new year.
- [MetricsSection.tsx](src/components/MetricsSection.tsx) imports the shared value instead of re-computing locally.

## Note (not addressed in this PR)
[index.html](index.html)'s \`<meta description>\` and \`og:description\` also embed "14+ years" as static text. Making those dynamic would require a Vite build-time substitution plugin or env var. Yearly manual edit there is fine for now; flag for later if the maintenance burden grows.

## Test plan
- [ ] CI passes (lint + type-check + build).
- [ ] After deploy: ExperienceSection sub-header reads "14+ years"; MetricsSection still shows "14+ Years Experience". When 2027 rolls in, both auto-bump to "15+" without code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)