### PR TITLE
chore(data): expand certifications list (3 -> 14)

### DIFF
--- a/src/data/resume.ts
+++ b/src/data/resume.ts
@@ -67,16 +67,60 @@ export const education: Education[] = [
 
 export const certifications: Certification[] = [
   {
-    name: 'Databricks Certified DE Professional',
+    name: 'Soda Certified: Cloud Fundamentals',
+    date: '07/2025',
+  },
+  {
+    name: 'Databricks Certified Data Engineer Professional',
     date: '12/2024',
   },
   {
-    name: 'Databricks Certified DE Associate',
+    name: 'Databricks Certified Data Engineer Associate',
     date: '12/2023',
   },
   {
-    name: 'Soda Certified: Cloud Fundamentals',
-    date: '07/2025',
+    name: 'Fundamentals of the Databricks Lakehouse Platform Accreditation',
+    date: '11/2023',
+  },
+  {
+    name: 'Building Batch Data Pipelines on Google Cloud',
+    date: '06/2022',
+  },
+  {
+    name: 'Google Cloud Big Data and Machine Learning Fundamentals',
+    date: '04/2022',
+  },
+  {
+    name: 'Baseline: Data, ML, AI',
+    date: '12/2021',
+  },
+  {
+    name: 'Engineer Data in Google Cloud',
+    date: '11/2021',
+  },
+  {
+    name: 'Data Engineering',
+    date: '11/2021',
+  },
+  {
+    name: 'Build and Optimize Data Warehouses with BigQuery',
+    date: '10/2021',
+  },
+  {
+    name: 'Developer Training for Spark & Hadoop',
+    date: '02/2017',
+  },
+  {
+    name: 'Oracle Database 11g: Advanced PL/SQL Ed 2 PRV',
+    date: '09/2013',
+  },
+  {
+    name: 'Oracle 11g XML Fundamentals Training',
+    date: '03/2013',
+  },
+  {
+    name: 'Oracle Database 11g: SQL Tuning Workshop Ed 2',
+    date: '12/2012',
   },
 ];
 


### PR DESCRIPTION
## Summary
[src/data/resume.ts](src/data/resume.ts) only had 3 certifications; LinkedIn shows 15. Added the missing 11 (in reverse chronological order). Cert names also normalized to match LinkedIn verbatim.

### Auto-updated downstream
- [MetricsSection.tsx](src/components/MetricsSection.tsx) reads \`certifications.length\` so 'Certifications' metric now shows '14+' instead of the prior factually-wrong '3+'.
- SkillsSection renders the full list — expect the cert grid to grow from 3 cards to 14.

### Excluded — please confirm
- **'Emergency First Aid & CPR/AED' (Saglik Bakanligi, Oct 2014)** — visible on your LinkedIn but excluded here because it's not a tech credential and could dilute the portfolio focus. If you want it shown, ping me or add a one-line entry yourself.

### Related places I checked but didn't change
- index.html meta description / og:description — don't reference cert count, nothing to update.
- JSON-LD Person schema — doesn't include certs.
- AboutSection / Hero copy — no cert claims to revise.

## Test plan
- [ ] CI passes.
- [ ] After deploy: SkillsSection shows 14 cert cards. MetricsSection 'Certifications' tile shows '14+'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)