### PR TITLE
chore: gitignore CLAUDE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ dist-ssr
 
 # Claude Code
 .claude/
+CLAUDE.md
 
 # Environment variables
 .env


### PR DESCRIPTION
## Summary
Add \`CLAUDE.md\` to [.gitignore](.gitignore) so it stays local-only. CLAUDE.md is a private brief for LLM/agent sessions; the public README is the user-facing doc.

## Test plan
- [ ] CI passes (no code change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)