### PR TITLE
chore(data): add cv.yaml as portable export of resume.ts

### DIFF
--- a/cv.yaml
+++ b/cv.yaml
@@ -1,0 +1,274 @@
+# Portable CV export. Mirrors src/data/resume.ts.
+# Both files MUST stay in sync — see .claude/commands/resume-agent.md for conventions.
+
+personalInfo:
+  fullName: Ali Yildiz
+  title: Data Engineer
+  email: ali.yildiz@xebia.com
+  phone: "+31 6 21 94 99 84"
+  linkedin: linkedin.com/in/yildizalicom
+  github: github.com/yildizali
+
+aboutMe:
+  summary: >-
+    Ali is a solution-oriented data enthusiast. To process data, one must
+    consider the entire end-to-end flow and know the objectives. Creating a
+    data flow without knowing its source or goal is like sailing a ship in
+    the ocean without a compass. Whether you let the waves carry you from
+    side to side or take the helm and change your direction against the
+    waves, is it time to take the helm?
+  biography: >-
+    Ali holds an MSc in Data Mining and his thesis was titled "Social
+    analysis by cities using K-means and SVM". He started as a Big Data
+    Engineer with PySpark and FMC components on data science based products.
+    Before his move to Xebia Data, Ali worked as a Cloud Data Architect at a
+    leading FMCG company. This made him proficient in understanding business
+    needs and building end-to-end data pipelines with cloud native
+    environments.
+
+roles:
+  - title: Big Data Engineer / Cloud Data Architect
+    description: Building cloud-native solutions for Big Data & Machine Learning Pipelines.
+  - title: Expert Big Data Engineer
+    description: >-
+      Building streaming, batch, or online end-to-end machine learning
+      pipelines. Building data pipelines for databases.
+  - title: Senior Software Specialist
+    description: Data Warehouse developer of the core banking system.
+
+education:
+  - startYear: 2013
+    endYear: 2016
+    degree: MSc
+    field: Computer Engineering (Data Mining)
+    institution: Suleyman Demirel University
+  - startYear: 2009
+    endYear: 2010
+    degree: BSc
+    field: Informatics Engineering
+    institution: University Of Coimbra
+  - startYear: 2005
+    endYear: 2011
+    degree: BSc
+    field: Computer Engineering
+    institution: Sakarya University
+
+certifications:
+  - name: "Soda Certified: Cloud Fundamentals"
+    date: 07/2025
+  - name: Databricks Certified Data Engineer Professional
+    date: 12/2024
+  - name: Databricks Certified Data Engineer Associate
+    date: 12/2023
+  - name: Fundamentals of the Databricks Lakehouse Platform Accreditation
+    date: 11/2023
+  - name: Building Batch Data Pipelines on Google Cloud
+    date: 06/2022
+  - name: Google Cloud Big Data and Machine Learning Fundamentals
+    date: 04/2022
+  - name: "Baseline: Data, ML, AI"
+    date: 12/2021
+  - name: Engineer Data in Google Cloud
+    date: 11/2021
+  - name: Data Engineering
+    date: 11/2021
+  - name: Build and Optimize Data Warehouses with BigQuery
+    date: 10/2021
+  - name: Developer Training for Spark & Hadoop
+    date: 02/2017
+  - name: "Oracle Database 11g: Advanced PL/SQL Ed 2 PRV"
+    date: 09/2013
+  - name: Oracle 11g XML Fundamentals Training
+    date: 03/2013
+  - name: "Oracle Database 11g: SQL Tuning Workshop Ed 2"
+    date: 12/2012
+
+skills:
+  - category: Programming
+    skills: [Python, Spark, PySpark, Scala, SQL]
+  - category: Data Stack
+    skills: [DBT Core/Cloud, Airflow, Dagster]
+  - category: Cloud
+    skills: [GCP, AWS, Azure]
+  - category: Tech
+    skills: [Docker, Git, GitHub Actions, CI/CD]
+
+languages:
+  - language: Turkish
+    proficiency: Native
+  - language: English
+    proficiency: Fluent
+  - language: Dutch
+    proficiency: Beginner
+
+experiences:
+  - title: Data Platform Engineer / Senior Data Engineer
+    company: NIBC (via Xebia)
+    startDate: 2025 March
+    endDate: Present
+    description: >-
+      Worked on developing new features for the cloud data platform and
+      strengthening the system from a security perspective.
+    bullets:
+      - Implemented Soda Core and Soda Cloud as the data quality solution for the platform.
+      - Helped expand the data platform's architectural design through several Architectural Decision Records (ADRs).
+      - Deployed and maintained infrastructure on Azure using Terraform, including Azure Data Factory, dbt Cloud, Function Apps, Databricks, and networking components.
+      - Developed a set of best practices and standards for proper platform usage.
+      - Actively contributed as an individual contributor while also guiding and supporting fellow Data Engineers in delivering work in accordance with established standards.
+    techStack: [Azure, Terraform, Databricks, dbt Cloud, Soda Core, Azure Data Factory]
+
+  - title: Senior Data Engineer
+    company: Irish Rail - Iarnród Éireann (via Xebia)
+    startDate: 2024 December
+    endDate: 2025 February
+    description: >-
+      Spearheaded an IoT data integration project for Irish Railways
+      leveraging Apache NiFi, Grafana, and TimescaleDB to enhance real-time
+      monitoring and operational efficiency.
+    bullets:
+      - Designed and implemented a scalable data ingestion pipeline using Apache NiFi.
+      - Developed dynamic dashboards with Grafana for real-time insights.
+      - Optimized time-series data management with TimescaleDB.
+      - Collaborated with cross-functional teams to align IoT solutions with business objectives.
+      - Ensured high data accuracy and system reliability through rigorous testing and validation.
+      - Built PoC and first MVP of the Life Connect Project.
+    techStack: [Apache NiFi, Grafana, TimescaleDB, IoT, Data Integration]
+
+  - title: Senior Data Engineer
+    company: ING (via Xebia)
+    startDate: 2024 January
+    endDate: 2024 November
+    description: >-
+      Worked with the QA& team as a part of the Whole Sale Banking (WSB/A)
+      Tribe to build sustainability reports using DataBricks (PySpark) (DIAM)
+      which is running on Azure as a self managed K8s Cluster.
+    bullets:
+      - Building data pipelines on Kedro and Pure PySpark with Airflow, applying the best practices.
+      - Validating the results with published Reports.
+      - Optimizing PySpark models.
+      - Data pipeline migration from Kedro to pure PySpark.
+      - PoC works on existing frameworks.
+      - Implementing and improving the team's way of working.
+    techStack: [Azure, AKS, PySpark, Kedro, Python, Airflow]
+
+  - title: Senior Data Engineer
+    company: FedEx (via Xebia)
+    startDate: 2023 April
+    endDate: 2023 December
+    description: >-
+      Worked with the Online Shipping Data Team to build a data warehouse and
+      optimize the existing PySpark application.
+    bullets:
+      - Implemented best practices for DBT Core.
+      - Building data warehouse pipelines on DBT Core, applying the best practices.
+      - Optimizing PySpark models.
+      - Validating the data warehouse model.
+      - Implementing and improving the team's way of working.
+    techStack: [DBT Core, PySpark, K8s, GCP, BigQuery, GitHub]
+
+  - title: Senior Data Engineer
+    company: Trustmark (via Xebia)
+    startDate: 2023 March
+    endDate: 2023 May
+    description: >-
+      Worked with the team of Xebia Consultants and the Trustmark team to
+      build a Data Platform and Dashboards from scratch.
+    bullets:
+      - Implemented best practices by DBT Core.
+      - Building Data Platform from scratch using DBT Cloud and DBT Core.
+      - Building CI/CD pipelines using GitHub Actions and DBT Cloud.
+      - Reporting and Dashboarding on Preset.io.
+      - Data Transformations and Dori built using GCP BigQuery.
+    techStack: [GCP, BigQuery, DBT Cloud, Preset.io, GitHub]
+
+  - title: Senior Data Engineer
+    company: International Flavors & Fragrances Inc. (via Xebia)
+    startDate: 2022 November
+    endDate: 2023 February
+    description: >-
+      Building MLOps platform for Data Scientists and Data Engineers. Worked
+      with a team of Xebia Consultants and the IFF team.
+    bullets:
+      - Implementation of MLOps Platform.
+      - Data Scientist's workbench on AWS Sagemaker.
+      - Terraform as IAC, GitLab as SCM, Jenkins as CI/CD.
+    techStack: [AWS, Sagemaker, MLOps, Terraform, Jenkins]
+
+  - title: Senior Data Engineer
+    company: Coca Cola İçecek
+    startDate: 2021 August
+    endDate: 2022 November
+    description: >-
+      Building native cloud solutions for Big Data & Machine Learning
+      pipelines. Built architectural designs and developed solutions with
+      data scientists and solution architects.
+    bullets:
+      - Designing end-to-end data pipeline for Machine Learning & Artificial Intelligence.
+      - Performance and SQL tuning of existing data lake implementations and ML pipelines.
+      - PoC works with third party firms.
+    techStack:
+      - CloudSQL
+      - BigQuery
+      - Vertex AI
+      - DataProc
+      - Airflow
+      - Cloud Storage
+      - Cloud Functions
+      - Firestore
+      - Cloud Scheduler
+
+  - title: Senior Data Engineer
+    company: GarantiBBVA Technology
+    startDate: 2015 November
+    endDate: 2021 August
+    description: >-
+      Building streaming, batch, or online end-to-end machine learning
+      pipelines. Working as a scrumbridge with data scientists, data
+      engineers, and product owners. Research and development on big data
+      tools. Building data as a service framework on RedHat OpenShift cloud
+      platform with Spring Boot.
+    bullets:
+      - Designing end-to-end data pipelines for Machine Learning & Artificial Intelligence with Data Scientists.
+      - Worked with the Data Engineering team to create big data solutions.
+      - Worked with Solution Architects to create Data As A Service Framework.
+      - Worked with third party regulators to check legal data.
+      - Worked on Cloudera CDH clusters and Existing Dash implementations.
+    techStack:
+      - Spark
+      - Scala
+      - Python
+      - Oracle Exadata
+      - SQL Server
+      - Apache Kafka
+      - Hive
+      - HBase
+      - MongoDB
+      - Apache NiFi
+      - Spring Boot
+
+  - title: Datawarehouse Developer
+    company: IBTech Technology
+    startDate: 2012 September
+    endDate: 2015 October
+    description: >-
+      Data Warehouse developer of the core banking system. Built an
+      end-to-end insurance data warehouse project CignaFinans.
+    bullets:
+      - Insurance core development, design, implementation, deployment, testing, and maintenance, including requirements analysis.
+      - Conceptual, logical, and physical data modeling utilizing relational, dimensional, star, and snowflake schemas.
+      - ETL development and jobs design, implementation, unit testing, and production deployment.
+      - Micro strategy modeling, implementing business intelligence reports and designing dashboards.
+    techStack: [SAP DS, MicroStrategy, ODI, OBI, Oracle Exadata]
+
+  - title: Software Developer
+    company: BIS Çözüm
+    startDate: 2012 April
+    endDate: 2012 September
+    description: >-
+      Developed and maintained Infact Next banking-factoring products used by
+      more than 30 international companies.
+    bullets:
+      - Development, unit testing, and deployment of new features.
+      - Design and development of factoring, credit, and customer performance reports.
+      - Performance tuning on the existing framework.
+    techStack: [C#, ASP.NET, SQL Server, T-SQL]


### PR DESCRIPTION
## Summary
Adds [cv.yaml](cv.yaml) — a faithful YAML copy of [src/data/resume.ts](src/data/resume.ts).

### Why
- Standardizes the CV content in a design-agnostic, portable format. If you ever migrate the portfolio to another framework / static site / template, you can lift `cv.yaml` directly without parsing TypeScript.
- Treats the two files as synchronized sources of truth — the resume-agent convention (in \`.claude/commands/resume-agent.md\`) now requires any content change to update both files together.

### Site impact
None. The site continues to read from \`resume.ts\` at runtime. \`cv.yaml\` is an export, not a build input.

### Future option (not in this PR)
If we want \`cv.yaml\` to be the source of truth and \`resume.ts\` to be generated from it, we'd add a \`vite-plugin-yaml\`-style loader. Worth considering once you actually start a second design.

## Test plan
- [ ] CI passes (no code change, just a new YAML file).
- [ ] \`yamllint cv.yaml\` parses cleanly (optional local check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)