### PR TITLE
chore(scripts): add typecheck and check npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit",
+    "check": "npm run lint && npm run typecheck && npm run build"
   },
   "dependencies": {
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Summary
- Adds `typecheck` (`tsc --noEmit`) and `check` (`lint && typecheck && build`) npm scripts to mirror the CI pipeline locally.
- Enables a fast, single-command pre-PR validation matching `.github/workflows/ci.yml` exactly.

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run build` produces `dist/` (217.6 kB JS / 68.37 kB gzip)
- [x] `npm run check` runs all three sequentially
- [x] `npm run preview` serves the build at http://localhost:4173

🤖 Generated with [Claude Code](https://claude.com/claude-code)